### PR TITLE
build: Create CommonJS and ESM Distribution

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,13 +1,22 @@
 /* eslint-disable no-undef */
 const { build } = require("esbuild");
 
-// More details about esbuild: https://github.com/evanw/esbuild#command-line-usage
-build({
-  entryPoints: ["./src/main.js"],
-  outfile: "./dist/main.js",
+const config = {
   minify: true, //Remove whitespace, shorten identifiers, and use equivalent but shorter syntax
   bundle: true, // Bundle all dependencies into the output files
   sourcemap: true, // Emit a source map
+  target: ["es2020", "chrome58", "firefox57", "safari11", "edge16", "node14"],
+};
+
+build({
+  ...config,
+  entryPoints: ["./src/main.js"],
+  outfile: "./dist/main.js",
+  format: "cjs",
+}).catch(() => process.exit(1));
+build({
+  ...config,
+  entryPoints: ["./src/main.js"],
+  outfile: "./dist/main.mjs",
   format: "esm",
-  target: ['esnext']
 }).catch(() => process.exit(1));


### PR DESCRIPTION
I  know little about building and distributing Javascript libraries. This tries to:

* generate Output which is somewhat more suited to browsers currently in the wild
* generates a CJS module
* generates a separate ESM module, although this is not referenced specifficaly in package.json

This version works with current react apps (CRA) and jest as used by CRA.